### PR TITLE
Disable obsidian-sync application

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   - sealed-secrets/sealed-ghcr-credentials.yaml
   - sealed-secrets/github-andex-tokyo-creds.yaml
 
-  - applications/obsidian-sync.yaml
+  # - applications/obsidian-sync.yaml
   - applications/rize-dashboard.yaml
   - applications/datadog.yaml
 patches:


### PR DESCRIPTION
Comment out the obsidian-sync service in the kustomization.yaml to disable its deployment.